### PR TITLE
TASK64 - Ajuste no link de esqueci a senha para que não dispare juntamente com o evento submit do form

### DIFF
--- a/src/app/_views/login/login.component.html
+++ b/src/app/_views/login/login.component.html
@@ -28,9 +28,6 @@
                 <div class="form-outline form-white mb-4">
                   <div class="box-senha">
                     <label class="form-label" for="typePasswordX">SENHA</label>
-                    <p class="small mb-1 pb-lg-2"><button (click)="forgotPassword()" class="link" >Esqueceu a
-                        senha?</button>
-                    </p>
                   </div>
                   <input type="password" id="typePasswordX" class="form-control form-control-lg" placeholder="Senha"
                     formControlName="password" required />
@@ -44,6 +41,15 @@
                   <small>O usuário e/ou senha informado é inválido.</small>
                 </div>
               </form>
+
+              <br>
+
+              <!--O evento de clique de forgotPassword precisou ser colocado para fora do formulário, pois como formulário é reativo,
+              por algum motivo (acredito ser um bug do angular) ele está chamando o evento de submit junto com o evento de click.-->
+              <p class="small mb-1 pb-lg-2"><button (click)="forgotPassword()" class="link">Esqueceu a
+                  senha?</button>
+              </p>
+
             </div>
 
             <div class="botton-link">

--- a/src/app/_views/login/login.component.ts
+++ b/src/app/_views/login/login.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostBinding, HostListener, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { UserServiceService } from '../../_services/user/user-service.service';
 import { AlertService } from 'src/app/_shared/alert/alert.service';
 import { IAlert } from 'src/app/_interfaces/alert/ialert';
 import { ERROR } from 'src/environments/environment';
+import { eventListeners } from '@popperjs/core';
 
 @Component({
   selector: 'app-login',
@@ -17,6 +18,7 @@ export class LoginComponent implements OnInit {
   loginFormGroup!: FormGroup;
   loginSuccessful: boolean = true;
   alertMessage!: IAlert;
+  checkForgotPassword: boolean = false;
 
   constructor(private userService: UserServiceService, private route: Router, private alertService: AlertService) { }
 


### PR DESCRIPTION
O evento de clique que acionava a função forgotPassword() precisou ser colocado para fora do formulário, pois como formulário é reativo, por algum motivo (acredito ser um bug do angular) ele estava chamando o evento de submit junto com o evento de click e por este motivo ao clicar na tecla ENTER para logar no sistema a mensagem do evento de click no link esqueci minha senha era apresentada. Tentei procurar por algumas soluções na internet para não permitir acionar o evento de submit ao acionar o click e vice-versa, porém não encontrei nenhuma alternativa que nos desse algum êxito nesta questão. Consegui resolver o problema removendo o link Esqueceu a senha? para fora do formulário, centralizando ele no layout, conforme print abaixo:

![image](https://user-images.githubusercontent.com/11522458/174406725-a9b0d412-2f73-4249-b9fa-a7e854a368b2.png)
![image](https://user-images.githubusercontent.com/11522458/174406740-6f2b346a-c865-4631-9502-46b55c5506cc.png)
